### PR TITLE
PCM-3521: Added JWT-specific auth

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
 	"name": "redhat-access-pcm-ascension-common",
-	"version": "1.2.27",
+	"version": "1.2.28",
 	"main": "dist/redhat_access_pcm_ascension_common.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redhat_access_pcm_ascension_common",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --config webpack.minified.config.js --bail --progress --profile && webpack --config webpack.unminified.config.js --bail --progress --profile",


### PR DESCRIPTION
@vrathee @gandhikeyur @engineersamuel Please review.

https://projects.engineering.redhat.com/browse/PCM-3521

With JWT we get a couple of user attributes for free, unfortunately it isn't enough, so we still need to fire that users request, but now we can run it in paralel with account request, this saves about 2s on stage.